### PR TITLE
Touch support

### DIFF
--- a/Leaflet.Sleep.js
+++ b/Leaflet.Sleep.js
@@ -160,6 +160,8 @@ L.Map.Sleep = L.Handler.extend({
 
   _addSleepingListeners: function(){
     this._map.once('mouseover', this._wakePending, this);
+    L.Browser.touch &&
+      this._map.once('click', this._wakeMap, this);
   },
 
   _addAwakeListeners: function(){
@@ -170,6 +172,8 @@ L.Map.Sleep = L.Handler.extend({
     this._map.options.hoverToWake &&
       this._map.off('mouseover', this._wakePending, this);
     this._map.off('mousedown', this._wakeMap, this);
+    L.Browser.touch &&
+      this._map.off('click', this._wakeMap, this);
   },
 
   _removeAwakeListeners: function(){

--- a/Leaflet.Sleep.js
+++ b/Leaflet.Sleep.js
@@ -60,6 +60,9 @@ L.Map.Sleep = L.Handler.extend({
   _wakeMap: function () {
     this._stopWaiting();
     this._map.scrollWheelZoom.enable();
+    this._map.touchZoom.enable();
+    this._map.dragging.enable();
+    this._map.tap.enable();
     L.DomUtil.setOpacity( this._map._container, 1);
     this.sleepNote.style.opacity = 0;
     this._addAwakeListeners();
@@ -68,6 +71,9 @@ L.Map.Sleep = L.Handler.extend({
   _sleepMap: function () {
     this._stopWaiting();
     this._map.scrollWheelZoom.disable();
+    this._map.touchZoom.disable();
+    this._map.dragging.disable();
+    this._map.tap.disable();
     L.DomUtil.setOpacity( this._map._container, this._map.options.sleepOpacity);
     this.sleepNote.style.opacity = .4;
     this._addSleepingListeners();

--- a/Leaflet.Sleep.js
+++ b/Leaflet.Sleep.js
@@ -60,9 +60,11 @@ L.Map.Sleep = L.Handler.extend({
   _wakeMap: function () {
     this._stopWaiting();
     this._map.scrollWheelZoom.enable();
-    this._map.touchZoom.enable();
-    this._map.dragging.enable();
-    this._map.tap.enable();
+    if (this._map.tap) {
+      this._map.touchZoom.enable();
+      this._map.dragging.enable();
+      this._map.tap.enable();
+    }
     L.DomUtil.setOpacity( this._map._container, 1);
     this.sleepNote.style.opacity = 0;
     this._addAwakeListeners();
@@ -71,9 +73,12 @@ L.Map.Sleep = L.Handler.extend({
   _sleepMap: function () {
     this._stopWaiting();
     this._map.scrollWheelZoom.disable();
-    this._map.touchZoom.disable();
-    this._map.dragging.disable();
-    this._map.tap.disable();
+
+    if (this._map.tap) {
+      this._map.touchZoom.disable();
+      this._map.dragging.disable();
+      this._map.tap.disable();
+    }
     L.DomUtil.setOpacity( this._map._container, this._map.options.sleepOpacity);
     this.sleepNote.style.opacity = .4;
     this._addSleepingListeners();

--- a/Leaflet.Sleep.js
+++ b/Leaflet.Sleep.js
@@ -33,10 +33,15 @@ L.Map.Sleep = L.Handler.extend({
         onAdd: function () {
           const container = L.DomUtil.create('p', 'sleep-button');
           container.appendChild(document.createTextNode( this._map.options.sleepButtonText ));
-          L.DomEvent.addListener(container, 'click', function () {
+          var listener = function(e) {
             self._sleepButton.removeFrom(self._map);
             self._sleepMap();
-          });
+            e.preventDefault();
+            e.stopPropagation();
+            return false;
+          };
+          L.DomEvent.addListener(container, 'click', listener);
+          L.DomEvent.addListener(container, 'touchstart', listener);
 
           container.style.backgroundColor = 'white';
           container.style.padding = '5px';

--- a/Leaflet.Sleep.js
+++ b/Leaflet.Sleep.js
@@ -2,8 +2,11 @@ L.Map.mergeOptions({
   sleep: true,
   sleepTime: 750,
   wakeTime: 750,
+  wakeMessageTouch: 'Touch to Wake',
   sleepNote: true,
   sleepButtonOnTouch: true,
+  sleepButtonPosition: 'topright',
+  sleepButtonText: 'Disable map',
   hoverToWake: true,
   sleepOpacity:.7,
 });
@@ -25,11 +28,11 @@ L.Map.Sleep = L.Handler.extend({
     if (L.Browser.touch && this._map.options.sleepButtonOnTouch) {
       var DisableMapControl = L.Control.extend({
         options: {
-          position: 'topright'
+          position: this._map.options.sleepButtonPosition,
         },
         onAdd: function () {
           const container = L.DomUtil.create('p', 'sleep-button');
-          container.appendChild(document.createTextNode( 'Disable map' ));
+          container.appendChild(document.createTextNode( this._map.options.sleepButtonText ));
           L.DomEvent.addListener(container, 'click', function () {
             self._sleepButton.removeFrom(self._map);
             self._sleepMap();
@@ -38,6 +41,13 @@ L.Map.Sleep = L.Handler.extend({
           container.style.backgroundColor = 'white';
           container.style.padding = '5px';
           container.style.border = '2px solid gray';
+
+          if(this._map.options.sleepButtonStyle) {
+            var buttonStyleOverrides = this._map.options.sleepButtonStyle;
+            Object.keys(buttonStyleOverrides).map(function(key) {
+              container.style[key] = buttonStyleOverrides[key];
+            });
+          }
 
           return container;
         },
@@ -57,8 +67,14 @@ L.Map.Sleep = L.Handler.extend({
   },
 
   _setSleepNoteStyle: function() {
-    var noteString = this._map.options.wakeMessage ||
-                     ('Click ' + (this._map.options.hoverToWake?'or Hover ':'') + 'to Wake');
+    var noteString;
+
+    if(L.Browser.touch) {
+      noteString = this._map.options.wakeMessageTouch;
+    } else {
+      noteString = this._map.options.wakeMessage
+        || ('Click ' + (this._map.options.hoverToWake?'or Hover ':'') + 'to Wake');
+    }
     var style = this.sleepNote.style;
     if( this._map.options.sleepNote ){
       this.sleepNote.appendChild(document.createTextNode( noteString ));

--- a/Leaflet.Sleep.js
+++ b/Leaflet.Sleep.js
@@ -22,7 +22,7 @@ L.Map.Sleep = L.Handler.extend({
 
     this._setSleepNoteStyle();
 
-    if (this._map.tap && this._map.options.sleepButtonOnTouch) {
+    if (L.Browser.touch && this._map.options.sleepButtonOnTouch) {
       var DisableMapControl = L.Control.extend({
         options: {
           position: 'topright'
@@ -87,20 +87,18 @@ L.Map.Sleep = L.Handler.extend({
 
 
   _wakeMap: function (e) {
-    var wakedByTouch = e && e.originalEvent.sourceCapabilities.firesTouchEvents;
-
     this._stopWaiting();
     this._map.scrollWheelZoom.enable();
-    if (this._map.tap) {
+    if (L.Browser.touch) {
       this._map.touchZoom.enable();
       this._map.dragging.enable();
       this._map.tap.enable();
 
-      /* If the map was waked by a touch event we will never get
+      /* If the device has only a touchscreen we will never get
        * a mouseout event, so we add an extra button to put the map
        * back to sleep manually.
        */
-      if (wakedByTouch) {
+      if (L.Browser.touch) {
         this._map.addControl(this._sleepButton);
       }
     }
@@ -113,7 +111,7 @@ L.Map.Sleep = L.Handler.extend({
     this._stopWaiting();
     this._map.scrollWheelZoom.disable();
 
-    if (this._map.tap) {
+    if (L.Browser.touch) {
       this._map.touchZoom.disable();
       this._map.dragging.disable();
       this._map.tap.disable();

--- a/README.md
+++ b/README.md
@@ -42,11 +42,23 @@ These are the new options available for `L.map` and their defaults.
         // defines whether the user is prompted on how to wake map
         sleepNote: true,
 
-        // should hovering wake the map?
+        // should hovering wake the map? (only non-touch devices)
         hoverToWake: true,
 
-        // specify a custom message to notify users how to wake
+        // specify a custom message to notify users how to wake on non-touch device
         wakeMessage: ('Click ' + (hoverToWake?' or Hover ' : '') + 'to Wake'),
+
+        // specify a custom message to notify users how to wake on touch device
+        wakeMessageTouch: 'Touch to Wake',
+
+        // whether to show an extra map control on touch devices to sleep map after waking
+        sleepButtonOnTouch: true,
+
+        // Position of sleep button (allowed values topright, topleft, bottomright or bottomleft)
+        sleepButtonPosition: 'topright',
+
+        // Label of sleep button
+        sleepButtonText: 'Disable map',
 
         // opacity (between 0 and 1) of inactive map
         sleepOpacity: .7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-sleep",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "Leaflet.Sleep.js",
   "description": "Plugin for Leaflet for preventing unwanted scroll capturing",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-sleep",
-  "version": "0.3.1",
+  "version": "0.4.1",
   "main": "Leaflet.Sleep.js",
   "description": "Plugin for Leaflet for preventing unwanted scroll capturing",
   "scripts": {


### PR DESCRIPTION
This PR adds initial support for touch devices.

Like on the desktop the goal of this feature is to prevent map interaction to interfere with page scrolling. This is achieved by initially disabling `touchZoom` and `dragging` on such devices.

After tapping (also `mousedown` event) on the map it gets activated. Because you cannot leave the map area with a touchscreen and therefore you never get a `mouseout` event, I added an additional control to the map, using which the user can manually disable the map again. This can be very useful if the map view covers the whole screen and you want to "escape" from that.
