### PR TITLE
Make sleepNote style respect overridden styles

### DIFF
--- a/Leaflet.Sleep.js
+++ b/Leaflet.Sleep.js
@@ -179,7 +179,7 @@ L.Map.Sleep = L.Handler.extend({
     }
 
     L.DomUtil.setOpacity( this._map._container, this._map.options.sleepOpacity);
-    this.sleepNote.style.opacity = .4;
+    this.sleepNote.style.opacity = this._map.options.sleepNoteStyle.opacity;
     this._addSleepingListeners();
   },
 


### PR DESCRIPTION
Specifying an opacity value within sleepNoteStyle {} had no impact as the .4 value was hard coded.   
  
"this.sleepNote.style.opacity = this._map.options.sleepNoteStyle.opacity" allows the user's specified value to be respected.