### PR TITLE
Allow html for sleep note and fix opacity

### DIFF
--- a/Leaflet.Sleep.js
+++ b/Leaflet.Sleep.js
@@ -134,6 +134,7 @@ L.Map.Sleep = L.Handler.extend({
       style.maxWidth = '150px';
       style.transitionDuration = '.2s';
       style.zIndex = 5000;
+      style.opacity = '.6';
       style.margin = 'auto';
       style.textAlign = 'center';
       style.borderRadius = '4px';

--- a/Leaflet.Sleep.js
+++ b/Leaflet.Sleep.js
@@ -26,7 +26,7 @@ L.Control.SleepMapControl = L.Control.extend({
     var self = this;
     var container = L.DomUtil.create('p', 'sleep-button');
     var boundEvent = this._nonBoundEvent.bind(this);
-    container.appendChild( document.createTextNode( this.options.prompt ));
+    container.innerHTML = this.options.prompt;
     L.DomEvent.addListener(container, 'click', boundEvent);
     L.DomEvent.addListener(container, 'touchstart', boundEvent);
 

--- a/Leaflet.Sleep.js
+++ b/Leaflet.Sleep.js
@@ -129,12 +129,11 @@ L.Map.Sleep = L.Handler.extend({
     }
 
     if( this._map.options.sleepNote ){
-      this.sleepNote.appendChild(document.createTextNode( noteString ));
+      this.sleepNote.innerHTML = noteString;
       style.pointerEvents = 'none';
       style.maxWidth = '150px';
       style.transitionDuration = '.2s';
       style.zIndex = 5000;
-      style.opacity = '.6';
       style.margin = 'auto';
       style.textAlign = 'center';
       style.borderRadius = '4px';
@@ -179,7 +178,7 @@ L.Map.Sleep = L.Handler.extend({
     }
 
     L.DomUtil.setOpacity( this._map._container, this._map.options.sleepOpacity);
-    this.sleepNote.style.opacity = .4;
+    this.sleepNote.style.opacity = this._map.options.sleepNoteStyle && this._map.options.sleepNoteStyle.opacity? this._map.options.sleepNoteStyle.opacity : .4;
     this._addSleepingListeners();
   },
 


### PR DESCRIPTION
This PR allows to set the content of the sleep note as html. This should not break using regular strings, but now you can also use html, like images, icons, etc.

As a side-note, I also fixed the option to change the opacity for the sleep note. Before this was always set to .4, no matter what you passed, now .4 is the fallback.